### PR TITLE
commands: add alias for boosters command

### DIFF
--- a/modules/commands.lua
+++ b/modules/commands.lua
@@ -409,6 +409,7 @@ cmds['boosters'] = {function(_, msg)
 	}
 
 end, 'Shows all current guild boosters.'}
+cmds['dweebs'] = cmds['boosters']
 
 cmds['lenny'] = {function()
 	return '( ͡° ͜ʖ ͡°)'


### PR DESCRIPTION
this is more representative of the functionality of this command;
original alias retained for compatibility.