### PR TITLE
feature: number only mode

### DIFF
--- a/luna.lua
+++ b/luna.lua
@@ -43,6 +43,10 @@ client:on('messageCreate', function(msg)
 		modules.antispam(msg)
 	end
 
+	if modules.number then
+		modules.number(msg)
+	end
+
 end)
 
 client:on('messageDelete', function(message)

--- a/modules/number.lua
+++ b/modules/number.lua
@@ -1,4 +1,5 @@
 local discordia = require('discordia')
+local abs = math.abs
 
 local GENERAL = '381870553235193857' -- dapi #general
 local lastNumber = false
@@ -22,9 +23,10 @@ end
 
 return function(msg)
     local channel = msg.channel
+    local guild = msg.guild
     local bot = guild.me
 
-    if channel.id != GENERAL then
+    if channel.id ~= GENERAL then
         return
     end
 

--- a/modules/number.lua
+++ b/modules/number.lua
@@ -1,0 +1,36 @@
+local discordia = require('discordia')
+
+local GENERAL = '381870553235193857' -- dapi #general
+local lastNumber = false
+
+local function count(msg) do
+    if #msg.content == 0 then
+        return true
+    end
+    local num = tonumber(msg.content)
+    if num == nil then
+        return true
+    end
+    if not lastNumber then
+        lastNumber = num
+    end
+    if abs(lastNumber - num) > 1 then
+        return true
+    end
+    return false
+end
+
+return function(msg)
+    local channel = msg.channel
+    local bot = guild.me
+
+    if channel.id != GENERAL then
+        return
+    end
+
+    if bot:hasPermission(channel, 'manageMessages') then
+        if count(msg) then
+            return msg:delete()
+        end
+    end
+end


### PR DESCRIPTION
>Spooky Rectus í¾Today at 18:24
>
>i thought of a discord experiment. start with a number in a channel.
>everyone can only add or subtract 1, with a cool down. see how the value
>migrates over time.

known bugs:
if the bot restarts the number might reset, since the starting value is
set to the first number the bot receives

this wasn't tested i have no clue if it works or not